### PR TITLE
Update tarballs and Windows links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -4,8 +4,8 @@ PHP is a popular general-purpose scripting language that is especially suited to
 
 * [php.net](https://www.php.net) - The canonical website of the PHP project.  Everything you need or want to know about PHP is here.
 * [php/php-src](https://github.com/php/php-src) - Source code for PHP can be found right here on github
-  * [Release Tarballs](https://www.php.net/downloads) - Versioned release bundles, ready to build
-  * [Windows Binaries](https://windows.php.net) - Prebuilt executables for Windows
+  * [Release Tarballs](https://www.php.net/downloads.php?source=Y) - Versioned release bundles, ready to build
+  * [Windows Binaries](https://www.php.net/downloads.php?os=windows&osvariant=windows-downloads) - Prebuilt executables for Windows
 * [Documentation](https://www.php.net/manual) - Available in several translations
   * [Docbook Source](https://github.com/php/doc-en) - Open source documentation in XML
 * [Mailing Lists](https://www.php.net/mailing-lists.php) - All development discussion happens over email


### PR DESCRIPTION
This PR fixes the link for release tarballs after the changes to the downloads page. It also changes the link for Windows binaries as they are now available on the new downloads page.